### PR TITLE
Add Remote Debugger support to Sitecore Docker images

### DIFF
--- a/files/docker-entrypoint.ps1
+++ b/files/docker-entrypoint.ps1
@@ -1,2 +1,3 @@
 C:\Scripts\Watch-Directory.ps1 -Path 'C:\workspace' -Destination 'C:\inetpub\wwwroot\sitecore'
+C:\Scripts\Start-RemoteDebug.ps1
 C:\ServiceMonitor.exe w3svc

--- a/scripts/Add-Hosts.ps1
+++ b/scripts/Add-Hosts.ps1
@@ -19,7 +19,7 @@ function setHostEntries([hashtable] $entries) {
                     break
                 }
             }
-            if($match -eq $NULL) {
+            if($NULL -eq $match) {
                 $newLines += $line
             } else {
                 $entries.Remove($match)

--- a/scripts/Start-RemoteDebug.ps1
+++ b/scripts/Start-RemoteDebug.ps1
@@ -1,5 +1,5 @@
 Write-Host ("{0}: Starting 'msvsmon.exe'..." -f [DateTime]::Now.ToString("HH:mm:ss:fff"))
 
-& "C:\Program Files\Microsoft Visual Studio 15.0\Common7\IDE\Remote Debugger\x86\msvsmon.exe" /silent /noauth /anyuser
+& "C:\Program Files\Microsoft Visual Studio 15.0\Common7\IDE\Remote Debugger\x64\msvsmon.exe" /silent /noauth /anyuser
 
 Write-Host ("{0}: Started 'msvsmon.exe' on port 4020." -f [DateTime]::Now.ToString("HH:mm:ss:fff"))

--- a/scripts/Start-RemoteDebug.ps1
+++ b/scripts/Start-RemoteDebug.ps1
@@ -1,0 +1,5 @@
+Write-Host ("{0}: Starting 'msvsmon.exe'..." -f [DateTime]::Now.ToString("HH:mm:ss:fff"))
+
+& "C:\Program Files\Microsoft Visual Studio 15.0\Common7\IDE\Remote Debugger\x86\msvsmon.exe" /silent /noauth /anyuser
+
+Write-Host ("{0}: Started 'msvsmon.exe' on port 4020." -f [DateTime]::Now.ToString("HH:mm:ss:fff"))

--- a/scripts/Watch-Directory.ps1
+++ b/scripts/Watch-Directory.ps1
@@ -82,7 +82,7 @@ finally
     # Cleanup
     Get-EventSubscriber -SourceIdentifier "FileDeleted" | Unregister-Event
 
-    if ($watcher -ne $null)
+    if ($null -ne $watcher)
     {
         $watcher.Dispose()
         $watcher = $null

--- a/sitecore/Dockerfile
+++ b/sitecore/Dockerfile
@@ -7,7 +7,7 @@ ARG CONFIG_PACKAGE
 
 ADD files /Files
 
-RUN Expand-Archive -Path /Files/$Env:CONFIG_PACKAGE -DestinationPath /Files/Config 
+RUN Expand-Archive -Path /Files/$Env:CONFIG_PACKAGE -DestinationPath /Files/Config
 
 
 # Stage 1: create actual image
@@ -22,6 +22,19 @@ ARG SQL_SERVER="mssql"
 ARG SITE_NAME="sitecore"
 ARG SOLR_PORT=8983
 ARG SITECORE_PACKAGE
+
+# Install chocolatey
+RUN Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+
+# Install WebDeploy
+RUN choco install -y --params="Quiet" --limit-output webdeploy
+
+# Install IIS URL Rewrite
+RUN choco install -y --params="Quiet" --limit-output UrlRewrite
+
+# Install VS Remote Tools for debugging and vc redistributable runtime
+RUN choco install -y --params="Quiet" --limit-output vcredist2017
+RUN choco install -y --params="Quiet" --limit-output visualstudio2017-remotetools
 
 COPY files/*.pfx /Files/
 COPY files/license.xml /Files/
@@ -42,21 +55,6 @@ RUN /Scripts/Import-Certificate.ps1 -certificateFile $Env:SITECORE_CERT_PATH -se
 # Import XConnect certificate
 RUN /Scripts/Import-Certificate.ps1 -certificateFile $Env:XCONNECT_CERT_PATH -secret 'secret' -storeName 'My' -storeLocation 'LocalMachine'
 RUN /Scripts/Import-Certificate.ps1 -certificateFile $Env:SITECORE_CERT_PATH -secret 'secret' -storeName 'My' -storeLocation 'LocalMachine'
-
-# Install WebDeploy
-ENV WEBDEPLOY_MSI="webdeploy.msi"
-ADD http://download.microsoft.com/download/0/1/D/01DC28EA-638C-4A22-A57B-4CEF97755C6C/WebDeploy_amd64_en-US.msi ${WEBDEPLOY_MSI}
-RUN Start-Process msiexec.exe -ArgumentList '/i', $Env:WEBDEPLOY_MSI, '/quiet', '/norestart' -NoNewWindow -Wait
-
-# Install IIS URL Rewrite
-ENV URLREWRITE_MSI="urlrewrite.msi"
-ADD http://download.microsoft.com/download/D/D/E/DDE57C26-C62C-4C59-A1BB-31D58B36ADA2/rewrite_amd64_en-US.msi ${URLREWRITE_MSI}
-RUN Start-Process msiexec.exe -ArgumentList '/i', $Env:URLREWRITE_MSI, '/quiet', '/norestart' -NoNewWindow -Wait
-
-# Install chocolatey
-RUN Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
-
-RUN choco install -y --params="Quiet" vcredist2015
 
 # Install SIF
 RUN /Scripts/Install-SIF.ps1
@@ -90,15 +88,15 @@ RUN $solrUrl = 'https://solr:{0}/solr' -f $Env:SOLR_PORT; `
     -SqlProcessingTasksUser $Env:SQL_USER `
     -SqlProcessingTasksPassword $Env:SQL_SA_PASSWORD `
     -SqlReferenceDataUser $Env:SQL_USER `
-    -SqlReferenceDataPassword $Env:SQL_SA_PASSWORD ` 
+    -SqlReferenceDataPassword $Env:SQL_SA_PASSWORD `
 	-SqlExmMasterUser "sa" `
     -SqlExmMasterPassword $Env:SQL_SA_PASSWORD `
 	-SqlMessagingUser "sa" `
-    -SqlMessagingPassword $Env:SQL_SA_PASSWORD `	
+    -SqlMessagingPassword $Env:SQL_SA_PASSWORD `
     -SqlProcessingPoolsUser $Env:SQL_USER `
     -SqlProcessingPoolsPassword $Env:SQL_SA_PASSWORD `
     -SqlReportingUser $Env:SQL_USER `
-    -SqlReportingPassword $Env:SQL_SA_PASSWORD `  
+    -SqlReportingPassword $Env:SQL_SA_PASSWORD `
     -SqlMarketingAutomationUser $Env:SQL_USER `
     -SqlMarketingAutomationPassword $Env:SQL_SA_PASSWORD `
     -SolrUrl $solrUrl `
@@ -121,7 +119,7 @@ RUN Copy-Item /Config/*.* c:\inetpub\wwwroot\$Env:SITE_NAME\App_Config\Include
 # enable live-mode
 RUN mv C:\inetpub\wwwroot\sitecore\App_Config\Include\Examples\LiveMode.config.example C:\inetpub\wwwroot\sitecore\App_Config\Include\Examples\LiveMode.config
 
-# Add Host	
+# Add Host
 RUN /Scripts/Add-Hosts.ps1
 
 # Start site

--- a/xconnect/DockerFile
+++ b/xconnect/DockerFile
@@ -9,7 +9,7 @@ SHELL ["powershell", "-NoProfile", "-Command", "$ErrorActionPreference = 'Stop';
 
 ADD files/$CONFIG_PACKAGE /Files/
 
-RUN Expand-Archive -Path /Files/$Env:CONFIG_PACKAGE -DestinationPath /Files/Config 
+RUN Expand-Archive -Path /Files/$Env:CONFIG_PACKAGE -DestinationPath /Files/Config
 
 
 # Stage 1: create actual image
@@ -23,7 +23,19 @@ ARG SOLR_CORE_PREFIX="xp0"
 ARG SOLR_PORT="8983"
 ARG XCONNECT_PACKAGE
 
-SHELL ["powershell", "-NoProfile", "-Command", "$ErrorActionPreference = 'Stop';"] 
+SHELL ["powershell", "-NoProfile", "-Command", "$ErrorActionPreference = 'Stop';"]
+
+# Install chocolatey
+RUN Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+
+# Install WebDeploy
+RUN choco install -y --params="Quiet" --limit-output --no-progress webdeploy
+
+# Install IIS URL Rewrite
+RUN choco install -y --params="Quiet" --limit-output --no-progress UrlRewrite
+
+# Install VS Remote Tools for debugging
+RUN choco install -y --params="Quiet" --limit-output --no-progress visualstudio2017-remotetools
 
 COPY files/license.xml /Files/
 COPY files/$XCONNECT_PACKAGE /Files/
@@ -42,16 +54,6 @@ RUN /Scripts/Import-Certificate.ps1 -certificateFile $Env:XCONNECT_CERT_PATH -se
 RUN /Scripts/Import-Certificate.ps1 -certificateFile $Env:XCONNECT_CERT_PATH -secret 'secret' -storeName 'My' -storeLocation 'LocalMachine'
 
 RUN /Scripts/Install-SIF.ps1
-
-# Install WebDeploy
-ENV WEBDEPLOY_MSI="webdeploy.msi"
-ADD http://download.microsoft.com/download/0/1/D/01DC28EA-638C-4A22-A57B-4CEF97755C6C/WebDeploy_amd64_en-US.msi ${WEBDEPLOY_MSI}
-RUN Start-Process msiexec.exe -ArgumentList '/i', $Env:WEBDEPLOY_MSI, '/quiet', '/norestart' -NoNewWindow -Wait
-
-# Install IIS URL Rewrite
-ENV URLREWRITE_MSI="urlrewrite.msi"
-ADD http://download.microsoft.com/download/D/D/E/DDE57C26-C62C-4C59-A1BB-31D58B36ADA2/rewrite_amd64_en-US.msi ${URLREWRITE_MSI}
-RUN Start-Process msiexec.exe -ArgumentList '/i', $Env:URLREWRITE_MSI, '/quiet', '/norestart' -NoNewWindow -Wait
 
 RUN Remove-Website -Name 'Default Web Site'
 
@@ -83,18 +85,19 @@ RUN $solrUrl = 'https://solr:{0}/solr' -f $Env:SOLR_PORT; `
 	-SqlMessagingUser "sa" `
     -SqlMessagingPassword $Env:SQL_SA_PASSWORD `
     -SqlMarketingAutomationUser "sa" `
-    -SqlMarketingAutomationPassword $Env:SQL_SA_PASSWORD `    
+    -SqlMarketingAutomationPassword $Env:SQL_SA_PASSWORD `
     -SolrCorePrefix $Env:SOLR_CORE_PREFIX `
     -SolrURL $solrUrl `
     -Skip "CleanShards", "CreateShards", "CreateShardApplicationDatabaseServerLoginSqlCmd", "CreateShardManagerApplicationDatabaseUserSqlCmd", "CreateShard0ApplicationDatabaseUserSqlCmd", "CreateShard1ApplicationDatabaseUserSqlCmd", "ConfigureSolrSchemas"
 
 RUN Remove-Item -Recurse -Force -Path c:\inetpub\wwwroot\xconnect\App_Data\logs
-# Add Host	
+
+# Add Host entries for Docker services
 RUN /Scripts/Add-Hosts.ps1
 
-RUN Start-WebAppPool -Name $Env:SITE_NAME 
+RUN Start-WebAppPool -Name $Env:SITE_NAME
 RUN Start-Website -Name $Env:SITE_NAME
 
 EXPOSE 443
 
-ENTRYPOINT C:\ServiceMonitor.exe w3svc
+ENTRYPOINT ["powershell", "-NoProfile", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'Continue'; $verbosePreference='Continue';", "C:\\Scripts\\Start-RemoteDebug.ps1;", "C:\\ServiceMonitor.exe", "w3svc"]


### PR DESCRIPTION
To start a debugger session against any of the Sitecore Docker services follow the directions below:

1. Within Visual Studio the debugger `Attach to Process...` dialog click on the Connection target `Find...` button.

1. Select the desired target connection from the list of running Sitecore Docker containers.

The target connection displays the container ID of any running Docker containers that contain a running a `msvsmon` process.

![image](https://user-images.githubusercontent.com/1688482/45186983-2a6c2800-b227-11e8-930b-aad2ca3a8b55.png)

Reference: [Remote debugging in Visual Studio](https://docs.microsoft.com/en-us/visualstudio/debugger/remote-debugging)

